### PR TITLE
Merge pull request #9 from edwinyoung/mac-support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ points to `$HOME/.helm/`, to the path `$HOME/.helm/$version`.
 
 ## Support
 Currently helmenv supports the following OSes
-- Mac OS X (64bit) - not really tested
+- macOS (64bit)
 - Linux
   - 32bit
   - 64bit
@@ -14,25 +14,25 @@ Currently helmenv supports the following OSes
   - Arm64
 
 ## Installation
-1. Check out helmenv into any path (`${HOME}/.helmenv` in the example)
+1. Check out helmenv into any path (`${HOME}/.helm` in the example)
 
 ```bash
-git clone https://github.com/alexppg/helmenv.git ~/.helmenv
+git clone https://github.com/alexppg/helmenv.git ~/.helm
 ```
 
-2. Add `~/.bin` to your `$PATH`
+2. Add `~/.helm` to your `$PATH`
 
 ```bash
-echo 'export PATH="$HOME/.bin:$PATH"' >> ~/.bashrc
+echo 'export PATH="$HOME/.helm:$PATH"' >> ~/.bashrc
 # Or
-echo 'export PATH="$HOME/.bin:$PATH"' >> ~/.zshrc
+echo 'export PATH="$HOME/.helm:$PATH"' >> ~/.zshrc
 ```
 
 3. Source the script
 ```bash
-echo 'source $HOME/.helmenv/helmenv.sh' >> ~/.bashrc
+echo 'source $HOME/.helm/helmenv.sh' >> ~/.bashrc
 # Or
-echo 'source $HOME/.helmenv/helmenv.sh' >> ~/.zshrc
+echo 'source $HOME/.helm/helmenv.sh' >> ~/.zshrc
 ```
 
 ## Usage
@@ -107,8 +107,7 @@ The version v2.12.3 is uninstalled!
 ```
 
 ## Related Projects
-There's a similar project for managing [kubectl
-versions](https://github.com/alexppg/kbenv).
+There's a similar project for managing [kubectl versions](https://github.com/alexppg/kbenv).
 
 ## License
 GPL3

--- a/helmenv.sh
+++ b/helmenv.sh
@@ -3,12 +3,12 @@
 function _helmenv_test_requirements {
     if [[ ! "$(command -v curl)" ]]
     then
-        echo "You must install curl"
-        exit 1
+        echo "helmenv: You must install curl"
+        exit 0
     elif [[ ! "$(command -v jq)" ]]
     then
-         echo "You must install jq"
-         exit 1
+         echo "helmenv: You must install jq"
+         exit 0
     fi
 
     # macOS: verify greadlink installed

--- a/helmenv.sh
+++ b/helmenv.sh
@@ -221,7 +221,6 @@ function helmenv_init () {
     HELM_OS_ARCH="$(_helmenv_get_os_and_arch)"
     _helmenv_test_requirements
     [[ $? = 1 ]] && return 1
-    echo "rc: $?"
     if [[ "$HELM_OS_ARCH" == "darwin"* ]]; then
         ACTUAL_VERSION="$(basename "$(greadlink -e "$HELM_BINARY_PATH/helm")")"
     else

--- a/helmenv.sh
+++ b/helmenv.sh
@@ -4,18 +4,18 @@ function _helmenv_test_requirements {
     if [[ ! "$(command -v curl)" ]]
     then
         echo "helmenv: You must install curl"
-        exit 0
+        return 0
     elif [[ ! "$(command -v jq)" ]]
     then
          echo "helmenv: You must install jq"
-         exit 0
+         return 0
     fi
 
     # macOS: verify greadlink installed
     if [[ "$HELM_OS_ARCH" == "darwin"* ]]; then
         if [[ ! "$(command -v greadlink)" ]]; then
             echo "helmenv: You must install coreutils"
-            exit 0
+            return 0
         fi
     fi
 }
@@ -219,6 +219,7 @@ function helmenv_help() {
 function helmenv_init () {
     HELM_BINARY_PATH="${HELM_BINARY_PATH:-$HOME/.helm/bin}"
     HELM_OS_ARCH="$(_helmenv_get_os_and_arch)"
+    _helmenv_test_requirements && [[ $? = 0 ]] && return 0
     if [[ "$HELM_OS_ARCH" == "darwin"* ]]; then
         ACTUAL_VERSION="$(basename "$(greadlink -e "$HELM_BINARY_PATH/helm")")"
     else
@@ -249,7 +250,7 @@ function helmenv() {
     ACTION="$1"
     ACTION_PARAMETER="$2"
 
-    _helmenv_test_requirements
+    _helmenv_test_requirements && [[ $? = 0 ]] && return 0
 
     case "${ACTION}" in
         "list-remote")

--- a/helmenv.sh
+++ b/helmenv.sh
@@ -10,6 +10,11 @@ function _helmenv_test_requirements {
         echo "helmenv: You must install jq"
         return 1
     fi
+    elif [[ ! "$(command -v file)" ]]
+    then
+        echo "helmenv: You must install file"
+        return 1
+    fi
 
     # macOS: verify greadlink installed
     if [[ "$HELM_OS_ARCH" == "darwin"* ]]; then

--- a/helmenv.sh
+++ b/helmenv.sh
@@ -102,7 +102,7 @@ function helmenv_install () {
 
     mkdir -p /tmp/helm
     tar -zxf "/tmp/helm-$VERSION.tar.gz" -C /tmp/helm
-    mv /tmp/helm/${os_arch}/helm "$HELM_BINARY_PATH/helm-$VERSION"
+    mv /tmp/helm/${HELM_OS_ARCH}/helm "$HELM_BINARY_PATH/helm-$VERSION"
     rm -r /tmp/helm
 
     if [[ -L "$HELM_BINARY_PATH/helm" ]]

--- a/helmenv.sh
+++ b/helmenv.sh
@@ -4,18 +4,18 @@ function _helmenv_test_requirements {
     if [[ ! "$(command -v curl)" ]]
     then
         echo "helmenv: You must install curl"
-        return 0
+        return 1
     elif [[ ! "$(command -v jq)" ]]
     then
          echo "helmenv: You must install jq"
-         return 0
+         return 1
     fi
 
     # macOS: verify greadlink installed
     if [[ "$HELM_OS_ARCH" == "darwin"* ]]; then
         if [[ ! "$(command -v greadlink)" ]]; then
             echo "helmenv: You must install coreutils"
-            return 0
+            return 1
         fi
     fi
 }
@@ -219,7 +219,9 @@ function helmenv_help() {
 function helmenv_init () {
     HELM_BINARY_PATH="${HELM_BINARY_PATH:-$HOME/.helm/bin}"
     HELM_OS_ARCH="$(_helmenv_get_os_and_arch)"
-    _helmenv_test_requirements && [[ $? = 0 ]] && return 0
+    _helmenv_test_requirements
+    [[ $? = 1 ]] && return 1
+    echo "rc: $?"
     if [[ "$HELM_OS_ARCH" == "darwin"* ]]; then
         ACTUAL_VERSION="$(basename "$(greadlink -e "$HELM_BINARY_PATH/helm")")"
     else
@@ -250,7 +252,8 @@ function helmenv() {
     ACTION="$1"
     ACTION_PARAMETER="$2"
 
-    _helmenv_test_requirements && [[ $? = 0 ]] && return 0
+    _helmenv_test_requirements
+    [[ $? = 1 ]] && return 1
 
     case "${ACTION}" in
         "list-remote")


### PR DESCRIPTION
- Checks that `coreutils` is installed for `greadlink` functionality on macOS
- Updates `helmenv_list` (from https://github.com/alexppg/helmenv/issues/5#issue-464180915)
- Allows the user to define `HELM_HOME`, `HELM_BINARY_PATH` env variables
- Changes default `HELM_BINARY_PATH` to `$HOME/.helm/bin` instead of `$HOME/.bin`
- Automatically adds `HELM_BINARY_PATH` to `PATH` (if it isn't already part of `PATH`)
- Updates README.md to reflect changes