### PR TITLE
mark active version for helmenv list

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ v2.0.2
 ```
 
 ### helmenv list
-List installed versions:
+List installed versions, and show an asterisk after the currently active version:
 ```bash
 $ helmenv list
 v2.10.0
 v2.11.0
-v2.12.3
+v2.12.3 *
 ```
 
 ### helmenv install


### PR DESCRIPTION
Sometimes it's helpful to show which version is in use during listing all installed versions. 

This PR modifies the output of `helmenv list` slightly to mark the currently active version -- putting an asterisk after it.

```
$> helmenv list
v2.16.3 *
v3.1.1
```